### PR TITLE
Resolve TypeScript files for module imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,11 @@
   "settings": {
     "jsdoc": {
       "mode": "typescript"
-    }
+    },
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    },
   }
 }


### PR DESCRIPTION
Without adding TS file extensions to `.eslintrc`, linting errors will show even when modules are successfully imported.